### PR TITLE
Bugfix: display lifetime statistics in report instead of year-to-date

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog for mtlstats
 
+## current
+- Bugfix: Display lifetime stats ib report, not YTD
+
 ## 0.8.0
 - Bugfix: removed quotation marks from goalie names in report
 - Allow lower case player names

--- a/src/Mtlstats/Report.hs
+++ b/src/Mtlstats/Report.hs
@@ -169,8 +169,8 @@ gameDate gs = fromMaybe "" $ do
   Just $ m ++ " " ++ d ++ " " ++ y
 
 playerReport :: Int -> String -> [(Player, PlayerStats)] -> [String]
-playerReport width label ps =
-  filteredPlayerReport width label (const True) ps
+playerReport width label =
+  filteredPlayerReport width label (const True)
 
 filteredPlayerReport
   :: Int

--- a/src/Mtlstats/Report.hs
+++ b/src/Mtlstats/Report.hs
@@ -151,10 +151,10 @@ lifetimeStatsReport :: Int -> ProgState -> [String]
 lifetimeStatsReport width s = let
   db = s^.database
 
-  playerStats = map (\p -> (p, p^.pYtd))
+  playerStats = map (\p -> (p, p^.pLifetime))
     $ db^.dbPlayers
 
-  goalieStats = map (\g -> (g, g^.gYtd))
+  goalieStats = map (\g -> (g, g^.gLifetime))
     $ db^.dbGoalies
 
   in playerReport width "LIFETIME" playerStats


### PR DESCRIPTION
Story at: https://trello.com/c/s3I5zRfJ/64-lifetime-stats-displaying-incorrectly-in-report